### PR TITLE
Add cached pinNumber calculation for Pin-Class

### DIFF
--- a/PropWare/gpio/pin.h
+++ b/PropWare/gpio/pin.h
@@ -61,7 +61,7 @@ class Pin : public Port {
         Pin (const PropWare::Pin::Mask mask = NULL_PIN)
                 : Port(mask),
                   m_channel(Channel::A) {
-			this->update_pin_number();
+			update_pin_number();
         }
 
         /**
@@ -78,7 +78,7 @@ class Pin : public Port {
          */
         void set_mask (const Pin::Mask mask) {
             this->Port::set_mask(mask);
-            this->update_pin_number();
+            update_pin_number();
         }
 
         /**
@@ -86,14 +86,14 @@ class Pin : public Port {
          *
          * @param[in]   pinNum  An integer 0-31 representing GPIO pins P0-P31
          */
-        void set_pin_num (const uint8_t pinNum) {
+        void set_pin_number (const uint8_t pinNum) {
 			set_mask(Pin::convert(pinNum));
         }
 
         /**
          * @brief       Get the pin's number (integer in the range: 0-31)
          */
-        uint32_t get_pin_num() const {
+        uint32_t get_pin_number() const {
             return m_pinNumber;
         }
 
@@ -204,7 +204,7 @@ if(iodt == 0)                               // If dt not initialized
 }
 */
             uint32_t ctr = static_cast<uint32_t>((8 + ((!state & 1) * 4)) << 26);        // POS detector counter setup
-            ctr += get_pin_num();                                                        // Add pin to setup
+            ctr += get_pin_number();                                                        // Add pin to setup
             const uint32_t startTime = CNT;                                              // Mark current time
             if (CTRA == 0) {
                 // If CTRA unused
@@ -243,7 +243,7 @@ if(iodt == 0)                               // If dt not initialized
             this->stop_hardware_pwm();
 
             const uint32_t frq = static_cast<uint32_t>((UINT32_MAX + 1ULL) * frequency / CLKFREQ);
-            const uint32_t ctr = (4 << 26) | get_pin_num();
+            const uint32_t ctr = (4 << 26) | get_pin_number();
             if (Channel::A == this->m_channel) {
                 FRQA = frq;
                 PHSA = 0;

--- a/PropWare/gpio/pin.h
+++ b/PropWare/gpio/pin.h
@@ -77,6 +77,10 @@ class Pin : public Port {
          */
         void set_mask (const Pin::Mask mask) {
             this->Port::set_mask(mask);
+            
+            for (exp = 31; x > 0; exp--)
+                x <<= 1;
+            this->m_pinNumber = exp;
         }
 
         /**
@@ -86,9 +90,16 @@ class Pin : public Port {
          */
         void set_pin_num (const uint8_t pinNum) {
             if (31 <= pinNum)
-                this->m_mask = Mask::NULL_PIN;
+                set_mask(Mask::NULL_PIN);
             else
-                this->m_mask = (uint32_t) (1 << pinNum);
+                set_mask((uint32_t) (1 << pinNum));
+        }
+
+        /**
+         * @brief       Get the pin's number (integer in the range: 0-31)
+         */
+        uint32_t get_pin_num() const {
+            return m_pinNumber;
         }
 
         Pin::Mask get_mask () const {
@@ -285,6 +296,7 @@ if(iodt == 0)                               // If dt not initialized
 
     private:
         Channel m_channel;
+        uint32_t m_pinNumber;
 };
 
 }

--- a/PropWare/gpio/pin.h
+++ b/PropWare/gpio/pin.h
@@ -61,6 +61,7 @@ class Pin : public Port {
         Pin (const PropWare::Pin::Mask mask = NULL_PIN)
                 : Port(mask),
                   m_channel(Channel::A) {
+			update_pin_number();
         }
 
         /**
@@ -77,11 +78,7 @@ class Pin : public Port {
          */
         void set_mask (const Pin::Mask mask) {
             this->Port::set_mask(mask);
-            
-            uint32_t pinNumber;
-            for (pinNumber = 31; x > 0; pinNumber--)
-                x <<= 1;
-            this->m_pinNumber = pinNumber;
+            update_pin_number();
         }
 
         /**
@@ -273,6 +270,15 @@ if(iodt == 0)                               // If dt not initialized
         }
 
     private:
+    	void update_pin_number() {
+            uint32_t pinNumber;
+            uint32_t pinMask = m_mask;
+            for (pinNumber = 32; pinMask > 0; pinNumber--)
+                pinMask <<= 1;
+            this->m_pinNumber = pinNumber;
+    	}
+
+
         /****************************************
          *** Nonsensical functions for a pin ***
          ****************************************/

--- a/PropWare/gpio/pin.h
+++ b/PropWare/gpio/pin.h
@@ -78,9 +78,10 @@ class Pin : public Port {
         void set_mask (const Pin::Mask mask) {
             this->Port::set_mask(mask);
             
-            for (exp = 31; x > 0; exp--)
+            uint32_t pinNumber;
+            for (pinNumber = 31; x > 0; pinNumber--)
                 x <<= 1;
-            this->m_pinNumber = exp;
+            this->m_pinNumber = pinNumber;
         }
 
         /**

--- a/PropWare/gpio/pin.h
+++ b/PropWare/gpio/pin.h
@@ -86,14 +86,14 @@ class Pin : public Port {
          *
          * @param[in]   pinNum  An integer 0-31 representing GPIO pins P0-P31
          */
-        void set_pin_number (const uint8_t pinNum) {
+        void set_pin_number (const uint_fast8_t pinNum) {
 			set_mask(Pin::convert(pinNum));
         }
 
         /**
          * @brief       Get the pin's number (integer in the range: 0-31)
          */
-        uint32_t get_pin_number() const {
+        uint_fast8_t get_pin_number() const {
             return m_pinNumber;
         }
 
@@ -295,8 +295,8 @@ if(iodt == 0)                               // If dt not initialized
         }
 
     private:
-        Channel m_channel;
-        uint32_t m_pinNumber;
+        Channel      m_channel;
+        uint_fast8_t m_pinNumber;
 };
 
 }

--- a/PropWare/gpio/pin.h
+++ b/PropWare/gpio/pin.h
@@ -61,7 +61,7 @@ class Pin : public Port {
         Pin (const PropWare::Pin::Mask mask = NULL_PIN)
                 : Port(mask),
                   m_channel(Channel::A) {
-			update_pin_number();
+			this->update_pin_number();
         }
 
         /**
@@ -78,7 +78,7 @@ class Pin : public Port {
          */
         void set_mask (const Pin::Mask mask) {
             this->Port::set_mask(mask);
-            update_pin_number();
+            this->update_pin_number();
         }
 
         /**
@@ -87,10 +87,7 @@ class Pin : public Port {
          * @param[in]   pinNum  An integer 0-31 representing GPIO pins P0-P31
          */
         void set_pin_num (const uint8_t pinNum) {
-            if (31 <= pinNum)
-                set_mask(Mask::NULL_PIN);
-            else
-                set_mask((uint32_t) (1 << pinNum));
+			set_mask(Pin::convert(pinNum));
         }
 
         /**
@@ -207,7 +204,7 @@ if(iodt == 0)                               // If dt not initialized
 }
 */
             uint32_t ctr = static_cast<uint32_t>((8 + ((!state & 1) * 4)) << 26);        // POS detector counter setup
-            ctr += Pin::convert(static_cast<Mask>(this->m_mask));                        // Add pin to setup
+            ctr += get_pin_num();                                                        // Add pin to setup
             const uint32_t startTime = CNT;                                              // Mark current time
             if (CTRA == 0) {
                 // If CTRA unused
@@ -246,7 +243,7 @@ if(iodt == 0)                               // If dt not initialized
             this->stop_hardware_pwm();
 
             const uint32_t frq = static_cast<uint32_t>((UINT32_MAX + 1ULL) * frequency / CLKFREQ);
-            const uint32_t ctr = (4 << 26) | static_cast<uint32_t>(convert(static_cast<Mask>(this->m_mask)));
+            const uint32_t ctr = (4 << 26) | get_pin_num();
             if (Channel::A == this->m_channel) {
                 FRQA = frq;
                 PHSA = 0;
@@ -271,11 +268,7 @@ if(iodt == 0)                               // If dt not initialized
 
     private:
     	void update_pin_number() {
-            uint32_t pinNumber;
-            uint32_t pinMask = m_mask;
-            for (pinNumber = 32; pinMask > 0; pinNumber--)
-                pinMask <<= 1;
-            this->m_pinNumber = pinNumber;
+    		this->m_pinNumber = Pin::convert(static_cast<Mask>(m_mask));
     	}
 
 

--- a/test/PropWare/pin_test.cpp
+++ b/test/PropWare/pin_test.cpp
@@ -85,8 +85,9 @@ TEST(SetMask) {
 TEST(SetPinNum) {
     testable = new PropWare::Pin();
 
-    testable->set_pin_num(TEST_PIN_NUM);
+    testable->set_pin_number(TEST_PIN_NUM);
     ASSERT_EQ(TEST_MASK, testable->get_mask());
+    ASSERT_EQ(TEST_PIN_NUM, testable->get_pin_number());
 
     tearDown();
 }


### PR DESCRIPTION
Added a cached calculation for the pin represented by an instance of `Pin`. Changing the mask of a `Pin`-instance should not happen that often, so I added the calculation of the number directly after changing the mask.
This is helpful if one wants to use counters, because they need the number of the pin instead of their mask.