### PR TITLE
Add initial version of timeout-reading

### DIFF
--- a/PropWare/serial/uart/uart.h
+++ b/PropWare/serial/uart/uart.h
@@ -107,6 +107,7 @@ class UART {
             /** The requested data width is not between 1 and 16 (inclusive) */    INVALID_DATA_WIDTH,
             /** The requested stop bit width is not between 1 and 14 (inclusive) */INVALID_STOP_BIT_WIDTH,
             /** Null pointer was passed as an argument */                          NULL_POINTER,
+            /** Reading from the serial connection timed out */                    TIMEOUT_ERROR,
             /** Last error code used by PropWare::UART */                          END_ERROR     = UART::NULL_POINTER
         } ErrorCode;
 

--- a/PropWare/serial/uart/uartrx.h
+++ b/PropWare/serial/uart/uartrx.h
@@ -230,14 +230,13 @@ class UARTRX : public UART
                 // Set RX as input
                 __asm__ volatile ("andn dira, %0" : : "r" (this->m_pin.get_mask()));
 
-                if(!this->shift_in_byte_array(buffer, length, timeout)) {
-					return (ErrorCode) 42;
-                }
+                if(!this->shift_in_byte_array(buffer, length, timeout))
+					return TIMEOUT_ERROR;
 
                 if (Parity::NO_PARITY != this->m_parity)
                     for (uint32_t i = 0; i < length; --i)
                         if (0 != this->check_parity((uint32_t) buffer[i]))
-                            return UART::PARITY_ERROR;
+                            return PARITY_ERROR;
             }
                 // If total receivable bits does not fit within a byte, shift in one word at a time (this offers no speed
                 // improvement - it is only here for user convenience)
@@ -245,7 +244,7 @@ class UARTRX : public UART
                 uint32_t      temp;
                 for (uint32_t i = 0; i < length; ++i) {
                     if (((uint32_t) -1) == (temp = this->receive()))
-                        return UART::PARITY_ERROR;
+                        return PARITY_ERROR;
                     buffer[i] = (char) temp;
                 }
             }

--- a/PropWare/serial/uart/uartrx.h
+++ b/PropWare/serial/uart/uartrx.h
@@ -27,7 +27,7 @@
 
 #include <PropWare/hmi/input/scancapable.h>
 #include <PropWare/serial/uart/uart.h>
-#include "pin.h"
+#include <PropWare/gpio/pin.h>
 
 namespace PropWare {
 

--- a/PropWare/serial/uart/uartrx.h
+++ b/PropWare/serial/uart/uartrx.h
@@ -110,13 +110,14 @@ class UARTRX : public UART
         }
 
         /**
-         * @brief       Receive one byte from the uart and abort when the given timeout passed prior to that.
+         * @brief       Receive one byte from the uart and abort when the given timeout passed.
          *
          * @param[in]   Timeout after which the function will exit without having received a byte.
          * @return      The received byte when successful, -1 on parity error, -2 if receiving timed out.
          *
-         * @warning     This method only works correctly with baudrates of up to 56000 when reading multiple consecutive
-         *              bytes with timeout, and up to 57600 when reading only the first byte with a timeout.
+         * @warning     If this method is used for multiple consecutive bytes, the baudrate should be lower
+         *              or equal to 56000. If this method is used only for the first byte of a multi-byte transmission,
+         *              normal max. baudrate can be expected to work.
          */
 		uint32_t receive (const uint32_t timeout) const {
             uint32_t rxVal;
@@ -179,6 +180,41 @@ class UARTRX : public UART
                 __asm__ volatile ("andn dira, %0" : : "r" (this->m_pin.get_mask()));
 
                 this->shift_in_byte_array(buffer, length);
+
+                if (Parity::NO_PARITY != this->m_parity)
+                    for (uint32_t i = 0; i < length; --i)
+                        if (0 != this->check_parity((uint32_t) buffer[i]))
+                            return UART::PARITY_ERROR;
+            }
+                // If total receivable bits does not fit within a byte, shift in one word at a time (this offers no speed
+                // improvement - it is only here for user convenience)
+            else {
+                uint32_t      temp;
+                for (uint32_t i = 0; i < length; ++i) {
+                    if (((uint32_t) -1) == (temp = this->receive()))
+                        return UART::PARITY_ERROR;
+                    buffer[i] = (char) temp;
+                }
+            }
+
+            return NO_ERROR;
+        }
+
+		/**
+		 * @brief       Reads multiple bytes into the given buffer.
+		 * @param[in]   
+         * @param[in]   timeout     Amount of clock cycles after which the function will stop waiting
+         *                          for a new byte to start. This timeout is not for all bytes read here.
+		 */
+        ErrorCode receive_array (uint8_t *buffer, uint32_t length, uint32_t timeout) const {
+            // Check if the total receivable bits can fit within a byte
+            if (8 >= this->m_receivableBits) {
+                // Set RX as input
+                __asm__ volatile ("andn dira, %0" : : "r" (this->m_pin.get_mask()));
+
+                if(!this->shift_in_byte_array(buffer, length, timeout)) {
+					return TIMEOUT_ERROR;
+                }
 
                 if (Parity::NO_PARITY != this->m_parity)
                     for (uint32_t i = 0; i < length; --i)
@@ -297,7 +333,7 @@ class UARTRX : public UART
             volatile uint32_t data       = -1;
             volatile uint32_t waitCycles = bitCycles;
 
-            timeoutCycles /= 8; //the instructions that do the polling need 8 cycles per pass
+            timeoutCycles /= 8; //the instruction that decrements the timeoutCounter needs 4 clock cycles
 
 #ifndef DOXYGEN_IGNORE
             __asm__ volatile (
@@ -482,6 +518,93 @@ class UARTRX : public UART
             [_msbMask] "r"(this->m_msbMask));
 #endif
         }
+
+
+        /**
+         * @brief       Shift in an array of data (FCache function)
+         *
+         * @param[out]  *buffer     Buffer where data can be stored
+         * @param[in]   length      Number of bytes that should be read from the port
+         * @param[in]   timeout     Amount of clock cycles after which the function will stop waiting
+         *                          for a new byte to start. This timeout is not for all bytes read here.
+         */
+        bool shift_in_byte_array (uint8_t *buffer, unsigned int length, uint32_t timeout) const {
+            uint32_t initWaitCycles    = (this->m_bitCycles >> 1) + this->m_bitCycles;
+            volatile uint32_t timeLeft = 0;
+
+            timeout /= 8; //the instruction that decrements the timeoutCounter needs 4 clock cycles
+
+#ifndef DOXYGEN_IGNORE
+            // Initialize variables
+            __asm__ volatile (
+#define ASMVAR(name) FC_ADDR(#name "%=", "ShiftInArrayDataStart%=")
+            FC_START("ShiftInArrayDataStart%=", "ShiftInArrayDataEnd%=")
+                    "       jmp #" FC_ADDR("outerLoop%=", "ShiftInArrayDataStart%=") "                          \n\t"
+
+                    // Temporary variables
+                    "bitIdx%=:                                                                                  \n\t"
+                    "       nop                                                                                 \n\t"
+                    "waitCycles%=:                                                                              \n\t"
+                    "       nop                                                                                 \n\t"
+                    "data%=:                                                                                    \n\t"
+                    "       nop                                                                                 \n\t"
+                    "       mov " ASMVAR(data) ", #0                                                            \n\t"
+
+                    "outerLoop%=:                                                                               \n\t"
+                    // Initialize the index variable
+                    "       mov " ASMVAR(bitIdx) ", %[_bits]                                                    \n\t"
+                    // Re-initialize the timer
+                    "       mov " ASMVAR(waitCycles) ", %[_initWaitCycles]                                      \n\t"
+
+                    //reset timeout and wait for startBit
+                    "       mov    %[_timeLeft],   %[_timeout]                                                  \n\t"
+                    "awaitStart%=: "
+                    "       test   %[_rxMask],     ina  wz                                                      \n\t"
+                    " if_nz djnz   %[_timeLeft],   #" FC_ADDR("awaitStart%=", "ShiftInArrayDataStart%=") "      \n\t"
+                    // Begin the timer (even if we just timed out - for performance reasons)
+                    "       add " ASMVAR(waitCycles) ", CNT                                                     \n\t"
+					//timed out, jump to the end (timeLeft is 0 now)
+                    " if_nz  jmp   #" FC_ADDR("end%=", "ShiftInArrayDataStart%=") "                             \n\t"
+
+                    "innerLoop%=:                                                                               \n\t"
+                    // Wait for the next bit
+                    "       waitcnt " ASMVAR(waitCycles) ", %[_bitCycles]                                       \n\t"
+                    "       shr " ASMVAR(data) ", #1                                                            \n\t"
+                    "       test %[_rxMask], ina wz                                                             \n\t"
+                    "       muxnz " ASMVAR(data) ", %[_msbMask]                                                 \n\t"
+                    "       djnz " ASMVAR(bitIdx) ", #" FC_ADDR("innerLoop%=", "ShiftInArrayDataStart%=") "     \n\t"
+
+                    // Write the word back to the buffer in HUB memory
+                    "       wrbyte " ASMVAR(data) ", %[_bufAdr]                                                 \n\t"
+
+                    // Clear the data register
+                    "       mov " ASMVAR(data) ", #0                                                            \n\t"
+                    // Increment the buffer address
+                    "       add %[_bufAdr], #1                                                                  \n\t"
+
+                    // Wait for the stop bits and the loop back
+                    "       waitpeq %[_rxMask], %[_rxMask]                                                      \n\t"
+                    "       djnz %[_length], #" FC_ADDR("outerLoop%=", "ShiftInArrayDataStart%=") "             \n\t"
+
+					"end%=: "
+                    FC_END("ShiftInArrayDataEnd%=")
+#undef ASMVAR
+            :// Outputs
+            [_bufAdr] "+r"(buffer),
+            [_length] "+r"(length),
+			[_timeLeft] "+r"(timeLeft)
+            :// Inputs
+            [_rxMask] "r"(this->m_pin.get_mask()),
+            [_bits] "r"(this->m_receivableBits),
+            [_bitCycles] "r"(this->m_bitCycles),
+            [_initWaitCycles] "r"(initWaitCycles),
+            [_msbMask] "r"(this->m_msbMask),
+			[_timeout] "r"(timeout));
+#endif
+
+			return (0 != timeLeft);
+        }
+
 
         /**
          * @brief       Check parity for a received value

--- a/PropWare/serial/uart/uartrx.h
+++ b/PropWare/serial/uart/uartrx.h
@@ -113,7 +113,7 @@ class UARTRX : public UART
          *
          * @return       An ErrorCode that specifies if something went wrong, and what.
          */
-        ErrorCode receive (uint8_t& data) const {
+        ErrorCode receive (uint32_t& data) const {
             uint32_t rxVal = this->shift_in_data(this->m_receivableBits, this->m_bitCycles,
 									             this->m_pin.get_mask(), this->m_msbMask);
 
@@ -136,10 +136,10 @@ class UARTRX : public UART
          *               or equal to 56000. If this method is used only for the first byte of a multi-byte transmission,
          *               normal max. baudrate can be expected to work.
          */
-        ErrorCode receive (uint8_t& data, uint32_t timeout) const {
+        ErrorCode receive (uint32_t& data, uint32_t timeout) const {
             uint32_t rxVal = this->shift_in_data(this->m_receivableBits, this->m_bitCycles, this->m_pin.get_mask(),
                                         this->m_msbMask, timeout);
-			if(-1 == rxVal)
+			if(static_cast<uint32_t>(-1) == rxVal)
 				return TIMEOUT_ERROR;
 
             if (static_cast<bool>(this->m_parity) && 0 != this->check_parity(rxVal))
@@ -238,10 +238,13 @@ class UARTRX : public UART
                 // If total receivable bits does not fit within a byte, shift in one word at a time (this offers no speed
                 // improvement - it is only here for user convenience)
             else {
-                ErrorCode temp;
+                ErrorCode err;
+                uint32_t temp;
                 for (uint32_t i = 0; i < length; ++i) {
-					if(NO_ERROR != (temp = this->receive(buffer[i], timeout)))
-						return temp;
+					if(NO_ERROR != (err = this->receive(temp, timeout)))
+						return err;
+					else
+						buffer[i] = temp;
                 }
             }
 


### PR DESCRIPTION
Added an initial version of reading with a timeout functionality. (only one byte for now)
This is done by polling for a start-bit instead of using the hardware-functionality (`waitpne`). For a nice and fast way of io-polling with a timeout, I used Phil's approach from [here](http://forums.parallax.com/discussion/comment/774604#Comment_774604)