### PR TITLE
[Bugfix UART] Fix parity check

### DIFF
--- a/PropWare/serial/uart/uartrx.h
+++ b/PropWare/serial/uart/uartrx.h
@@ -433,9 +433,11 @@ class UARTRX : public UART
             [_parityMask] "r"(wideParityMask));
 
             if (Parity::ODD_PARITY == this->m_parity) {
-                if (evenParityResult != (rxVal & this->m_parityMask))
+                //if using odd parity, the result should be different from evenParity
+                if (evenParityResult == (rxVal & this->m_parityMask))
                     return UART::PARITY_ERROR;
-            } else if (evenParityResult == (rxVal & this->m_parityMask))
+            } else if (evenParityResult != (rxVal & this->m_parityMask))
+                //if using even parity, the result should be that of evenParity
                 return UART::PARITY_ERROR;
 
             return UART::NO_ERROR;


### PR DESCRIPTION
I'm not completely sure about that one, but I think the parity-check was inverted.

I noticed that every communication with any type of parity fails. When talking with an Arduino (Mega 2560):
switching the arduino to `even` and the Propeller to `odd` parity worked.