### PR TITLE
bug fix: changed loop to increment at end

### DIFF
--- a/PropWare/filesystem/filewriter.h
+++ b/PropWare/filesystem/filewriter.h
@@ -70,8 +70,9 @@ class FileWriter : virtual public File, public PrintCapable {
             PropWare::ErrorCode err;
 
             char *s = (char *) string;
-            while (*s++) {
+            while (*s) {
                 check_errors(this->safe_put_char(*s));
+                s++;
             }
 
             return NO_ERROR;


### PR DESCRIPTION
I unfortunately didn't have time to update the test and look more thoroughly but I wanted to send this to you since I ran into the issue earlier.

The loop was incrementing before the character write happens, effectively chopping off the first character and outputting an extra null byte at the end.  The fix is simple.